### PR TITLE
fix: typo fix

### DIFF
--- a/src/content/docs/reference/methods.mdx
+++ b/src/content/docs/reference/methods.mdx
@@ -142,7 +142,7 @@ ids: <Tag color="cyan">string[]</Tag><span style="margin-right:8px;">|</span><Ta
 <Alert color="warning">
 ``` javascript
 chart.remove('flyLine',['1-2']);
-chart.remove('flyLine',['removeAll']);
+chart.remove('flyLine','removeAll');
 ```
 </Alert>
 


### PR DESCRIPTION
修改了示例代码中的参数错误，将'removeAll'参数从数组改为了字符串：

![image](https://github.com/JavaScriptam/earth-flyline-docs/assets/20255358/7f08dcfb-376c-46b4-ab34-8a1e7ea4c849)
